### PR TITLE
Filter symbols for base to prevent error while fetching

### DIFF
--- a/src/components/latestrates/LatestRatesFetcher.tsx
+++ b/src/components/latestrates/LatestRatesFetcher.tsx
@@ -18,7 +18,8 @@ const LatestRatesFetcher: React.FC = () => {
 
   useEffect(() => {
     (async () => {
-      const { data, error } = await fetchLatestRates(base, symbols);
+      const filteredSymbols = symbols.filter(symbol => symbol !== base);
+      const { data, error } = await fetchLatestRates(base, filteredSymbols);
 
       if (error) setResult({ error });
       if (data) setResult({ data });


### PR DESCRIPTION
fixes #1

the api that is used somehow cannot handle requests which do include `EUR` as base and  symbols .